### PR TITLE
Fixing specs failures

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -15,16 +15,16 @@ class maxscale::install {
 
 
         apt::source { 'maxscale':
-          location   => $repo_location,
-          release    => $maxscale::repo_release,
-          repos      => $maxscale::repo_repository,
-          key        => {
+          location => $repo_location,
+          release  => $maxscale::repo_release,
+          repos    => $maxscale::repo_repository,
+          key      => {
             'id'     => $maxscale::repo_fingerprint,
             'server' => $maxscale::repo_keyserver,
           },
-          include    => {
-            'deb'    => true,
-            'src'    => false,
+          include  => {
+            'deb' => true,
+            'src' => false,
           },
         }
 

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -21,7 +21,7 @@ define maxscale::instance (
   $confdir = dirname($configfile)
 
   ensure_resource( 'file', path_tree([
-    $confdir, $logdir, $cachedir, $datadir, $piddir, $errmsgsys_path 
+    $confdir, $logdir, $cachedir, $datadir, $piddir, $errmsgsys_path
     ]), { ensure => directory, })
 
   file { $configfile:
@@ -35,8 +35,8 @@ define maxscale::instance (
   file { "/etc/init.d/${service_name}":
     ensure  => present,
     content => template('maxscale/maxscale.initd.erb'),
-    require => [ File [$configfile], ],
-    notify  => [ Service[$service_name], ],
+    require => File[$configfile],
+    notify  => Service[$service_name],
   }
 
   service { $service_name:

--- a/spec/classes/maxscale_spec.rb
+++ b/spec/classes/maxscale_spec.rb
@@ -82,6 +82,8 @@ describe 'maxscale' do
         let(:params) {{ :install_repository => false, }}
         let(:facts) {{
           :osfamily        => osfamily,
+          :lsbdistid       => 'Ubuntu',
+          :lsbdistcodename => 'trusty',
         }}
         it { should compile.with_all_deps }
 


### PR DESCRIPTION
Adding facts about the lsbdist* even when no repository installation involved.
Was not showing up before as I forgot to set STRICT_VARIABLES locally.