### PR TITLE
Do not specify the owner and group on the confidir

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -21,11 +21,18 @@ define maxscale::instance (
   $confdir = dirname($configfile)
 
   ensure_resource( 'file', [
-    $confdir, $logdir, $cachedir, $datadir, $piddir, $errmsgsys_path
+    $logdir, $cachedir, $datadir, $piddir, $errmsgsys_path
   ], {
     ensure => directory,
     owner  => $svcuser,
     group  => $svcgroup,
+  })
+
+  # The config file could be /etc so we do not want the service user to be the
+  # owner. Plus Maxscale don't need to write in it, just need the rights on the
+  # config file
+  ensure_resource( 'file', $confdir, {
+    ensure => directory,
   })
 
   file { $configfile:

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -54,10 +54,11 @@ describe 'maxscale::instance' do
         .that_subscribes_to('File[/etc/maxscale.cnf]')
     end
     it { should_not contain_file('/etc/maxscale').with_ensure('directory') }
-    it { should contain_file('/var/cache/maxscale').with_ensure('directory') }
-    it { should contain_file('/var/log/maxscale').with_ensure('directory') }
-    it { should contain_file('/var/run/maxscale').with_ensure('directory') }
-    it { should contain_file('/var/lib/maxscale').with_ensure('directory') }
+    it { should contain_file('/etc').with_ensure('directory') }
+    it { should contain_file('/var/cache/maxscale').with_ensure('directory').with_owner('maxscale') }
+    it { should contain_file('/var/log/maxscale').with_ensure('directory').with_owner('maxscale') }
+    it { should contain_file('/var/run/maxscale').with_ensure('directory').with_owner('maxscale') }
+    it { should contain_file('/var/lib/maxscale').with_ensure('directory').with_owner('maxscale') }
   end
 
   context 'definition of a non-default instance' do


### PR DESCRIPTION
In the case we have config files in '/etc' directly for example, we should not set the owner of the parent folder of the configuration directory. We should only ensure that the configuration file has the correct rights.