### PR TITLE
Using the master.ini as the master section is now deprecated

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -44,19 +44,18 @@ class maxscale::params {
         'Binlog_Service'   => {
           'type'           => 'service',
           'router'         => 'binlogrouter',
-          'servers'        => 'master',
-          'router_options' => 'mariadb10-compatibility=1,server-id=10',
+          'router_options' => 'mariadb10-compatibility=1,server-id=10,binlogdir=/var/cache/maxscale/binlog',
           'user'           => 'maxscale',
           'passwd'         => 'PLEASE_CHANGE_ME!1!',
           'version_string' => '10.1.12-MariaDB-1~trusty',
         },
-        'Binlog Listener'   => {
+        'Binlog_Listener'   => {
           'type'            => 'listener',
           'service'         => 'Binlog_Service',
           'protocol'        => 'MySQLClient',
           'port'            => 3310,
         },
-        'Debug Interface'   => {
+        'Debug_Interface'   => {
           'type'            => 'service',
           'router'          => 'debugcli',
         },
@@ -64,24 +63,30 @@ class maxscale::params {
           'type'   => 'service',
           'router' => 'cli',
         },
-        'Debug Listener'   => {
+        'Debug_Listener'   => {
           'type'           => 'listener',
           'service'        => 'Debug Interface',
           'protocol'       => 'telnetd',
           'address'        => '127.0.0.1',
           'port'           => 4442,
         },
-        'CLI Listener'   => {
+        'CLI_Listener'   => {
           'type'         => 'listener',
           'service'      => 'CLI',
           'protocol'     => 'maxscaled',
           'port'         => 6603,
         },
-        'master'     => {
-          'type'     => 'server',
-          'address'  => '127.0.0.1',
-          'port'     => 3306,
-          'protocol' => 'MySQLBackend',
+      },
+      master_ini                 => {
+        directory                => '/var/cache/maxscale/binlog',
+        content                  => {
+          'binlog_configuration' => {
+            'master_host'        => '127.0.0.1',
+            'master_port'        => 3306,
+            'master_user'        => 'maxscale',
+            'master_password'    => 'PLEASE_CHANGE_ME!2!',
+            'filestem'           => 'mysql-bin',
+          },
         },
       },
     },

--- a/spec/classes/maxscale_spec.rb
+++ b/spec/classes/maxscale_spec.rb
@@ -99,19 +99,31 @@ describe 'maxscale' do
 
       describe "multi-instances maxscale on #{osfamily}" do
         let(:params) {{
-          :token               => 'abc123-456xyz',
-          :services_conf       => {
-            'default'          => {},
-            'foo'              => {
-              'ensure'         => 'stopped',
-              'logdir'         => '/var/log/maxscale_foo',
-              'cachedir'       => '/var/cache/maxscale_foo',
-              'datadir'        => '/var/data/maxscale_foo',
-              'piddir'         => '/var/run/maxscale_foo',
-              'errmsgsys_path' => '/var/lib/maxscale_foo',
-              'svcuser'        => 'nobody',
-              'svcgroup'       => 'nogroup',
-              'configfile'     => '/etc/maxscale/maxscale_foo.cnf',
+          :token                         => 'abc123-456xyz',
+          :services_conf                 => {
+            'default'                    => {},
+            'foo'                        => {
+              'ensure'                   => 'stopped',
+              'logdir'                   => '/var/log/maxscale_foo',
+              'cachedir'                 => '/var/cache/maxscale_foo',
+              'datadir'                  => '/var/data/maxscale_foo',
+              'piddir'                   => '/var/run/maxscale_foo',
+              'errmsgsys_path'           => '/var/lib/maxscale_foo',
+              'svcuser'                  => 'nobody',
+              'svcgroup'                 => 'nogroup',
+              'configfile'               => '/etc/maxscale/maxscale_foo.cnf',
+							'master_ini'               => {
+								'directory'              => '/var/cache/maxscale_foo/binlog',
+								'content'                => {
+									'binlog_configuration' => {
+										'master_host'        => '10.0.0.125',
+										'master_port'        => 3306,
+										'master_user'        => 'maxscale',
+										'master_password'    => 'PLEASE_CHANGE_ME!3!',
+										'filestem'           => 'mysql-bin',
+									},
+                },
+              },
             }
           }
         }}

--- a/templates/master.ini.erb
+++ b/templates/master.ini.erb
@@ -1,0 +1,7 @@
+<% @master_ini['content'].each do |section, items| -%>
+[<%= section %>]
+<% items.each do |item_key, item_value| -%>
+<%= item_key %>=<%=item_value%>
+<% end -%>
+
+<% end -%>


### PR DESCRIPTION
The usage of the master section in the maxscale.cnf is deprecated, this commit changes the module to takes care of modifying the module structure to handle that.
The documentation is also updated accordingly.