### PR TITLE
Fixing missing execution rights on the init script

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -60,6 +60,7 @@ define maxscale::instance (
   file { "/etc/init.d/${service_name}":
     ensure  => present,
     content => template('maxscale/maxscale.initd.erb'),
+    mode    => '0755',
     require => File[$configfile],
     notify  => Service[$service_name],
   }

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -36,6 +36,7 @@ describe 'maxscale::instance' do
     it do
       should contain_file('/etc/init.d/maxscale')\
         .with_ensure('present')\
+        .with_mode('0755')\
         .with_require('File[/etc/maxscale.cnf]')\
         .with_notify('Service[maxscale]')\
         .with_content(/^processname=maxscale$/)\
@@ -127,6 +128,7 @@ describe 'maxscale::instance' do
     it do
       should contain_file('/etc/init.d/maxscale_foo')\
         .with_ensure('present')\
+        .with_mode('0755')\
         .with_require('File[/etc/maxscale/maxscale_foo.cnf]')\
         .with_notify('Service[maxscale_foo]')\
         .with_content(/^processname=maxscale_foo$/)\


### PR DESCRIPTION
I forgot to add that when I pushed the 1st release.
By default the init script is created with rights 0644 so it cannot start the service.
