### PR TITLE
Upgrade to latest puppet-skeleton version from garethr

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,5 +1,3 @@
-Joseph Herlant (aerostitch)
-Evan Brewer
-Jeff Gage (jeffgage)
-Evan Breznyik (evanbreznyik)
-Alina Alexeeva
+Joseph Herlant
+Daniel Forsberg
+Johan Bloemberg

--- a/Gemfile
+++ b/Gemfile
@@ -1,15 +1,23 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
-group :test do
-  gem "json_pure", '2.0.1' if RUBY_VERSION < '2.0'
-  gem "rake"
-  gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.8.4'
-  gem "rspec-core", '< 3.2' if RUBY_VERSION < '1.9'
-  gem "puppet-lint"
-  gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
-  gem "puppet-syntax"
-  gem "puppetlabs_spec_helper"
-  gem "metadata-json-lint"
+puppetversion = ENV.key?('PUPPET_VERSION') ? ENV['PUPPET_VERSION'] : ['>= 3.3']
+gem "json", '< 2' if RUBY_VERSION < '2.0'
+gem "json_pure", '2.0.1' if RUBY_VERSION < '2.0'
+gem 'metadata-json-lint'
+gem 'puppet', puppetversion
+gem 'puppetlabs_spec_helper', '>= 1.0.0'
+gem 'puppet-lint', '>= 1.0.0'
+gem 'facter', '>= 1.7.0'
+gem 'rspec-puppet'
+
+# rspec must be v2 for ruby 1.8.7
+if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
+  gem 'rspec', '~> 2.0'
+  gem 'rake', '~> 10.0'
+elsif RUBY_VERSION < '2'
+  gem 'rubocop', '< 0.42'
+else
+  gem 'rubocop'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "https://rubygems.org"
+source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 group :test do
   gem "json_pure", '2.0.1' if RUBY_VERSION < '2.0'
@@ -15,12 +15,4 @@ end
 group :development do
   gem "travis"
   gem "travis-lint"
-  gem "vagrant-wrapper"
-  gem "puppet-blacksmith"
-  gem "guard-rake"
-end
-
-group :development, :system_tests do
-  gem "beaker"
-  gem "beaker-rspec"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,118 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (2.2.8)
+    addressable (2.4.0)
+    ast (2.3.0)
+    backports (3.6.8)
+    connection_pool (2.2.0)
+    diff-lcs (1.2.5)
+    ethon (0.9.1)
+      ffi (>= 1.3.0)
+    facter (2.4.6)
+      CFPropertyList (~> 2.2.6)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.10.0)
+      faraday (>= 0.7.4, < 0.10)
+    ffi (1.9.14)
+    gh (0.14.0)
+      addressable
+      backports
+      faraday (~> 0.8)
+      multi_json (~> 1.0)
+      net-http-persistent (>= 2.7)
+      net-http-pipeline
+    hiera (3.2.1)
+    highline (1.7.8)
+    json (2.0.2)
+    json_pure (1.8.3)
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    metaclass (0.0.4)
+    metadata-json-lint (0.0.11)
+      json
+      spdx-licenses (~> 1.0)
+    mocha (1.2.0)
+      metaclass (~> 0.0.1)
+    multi_json (1.12.1)
+    multipart-post (2.0.0)
+    net-http-persistent (3.0.0)
+      connection_pool (~> 2.2)
+    net-http-pipeline (1.0.1)
+    parser (2.3.1.4)
+      ast (~> 2.2)
+    powerpack (0.1.1)
+    puppet (4.7.0)
+      CFPropertyList (~> 2.2.6)
+      facter (> 2.0, < 4)
+      hiera (>= 2.0, < 4)
+      json_pure (~> 1.8)
+    puppet-lint (2.0.2)
+    puppet-syntax (2.1.0)
+      rake
+    puppetlabs_spec_helper (1.2.2)
+      mocha (~> 1.0)
+      puppet-lint (~> 2.0)
+      puppet-syntax (~> 2.0)
+      rspec-puppet (~> 2.0)
+    pusher-client (0.6.2)
+      json
+      websocket (~> 1.0)
+    rainbow (2.1.0)
+    rake (11.3.0)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-puppet (2.4.0)
+      rspec
+    rspec-support (3.5.0)
+    rubocop (0.44.1)
+      parser (>= 2.3.1.1, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.8.1)
+    spdx-licenses (1.1.0)
+    travis (1.8.2)
+      backports
+      faraday (~> 0.9)
+      faraday_middleware (~> 0.9, >= 0.9.1)
+      gh (~> 0.13)
+      highline (~> 1.6)
+      launchy (~> 2.1)
+      pusher-client (~> 0.4)
+      typhoeus (~> 0.6, >= 0.6.8)
+    travis-lint (2.0.0)
+      json
+    typhoeus (0.8.0)
+      ethon (>= 0.8.0)
+    unicode-display_width (1.1.1)
+    websocket (1.2.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  facter (>= 1.7.0)
+  metadata-json-lint
+  puppet (>= 3.3)
+  puppet-lint (>= 1.0.0)
+  puppetlabs_spec_helper (>= 1.0.0)
+  rspec-puppet
+  rubocop
+  travis
+  travis-lint
+
+BUNDLED WITH
+   1.13.3

--- a/examples/init.pp
+++ b/examples/init.pp
@@ -1,0 +1,12 @@
+# The baseline for module testing used by Puppet Labs is that each manifest
+# should have a corresponding test manifest that declares that class or defined
+# type.
+#
+# Tests are then run by using puppet apply --noop (to check for compilation
+# errors and view a log of events) or by fully applying the test in a virtual
+# environment (to compare the resulting system state to the desired state).
+#
+# Learn more about module testing here:
+# https://docs.puppet.com/guides/tests_smoke.html
+#
+include ::maxscale

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,7 +35,9 @@ class maxscale (
 
   if $install_repository == true {
     if $repo_custom_url == undef or $repo_custom_url == '' {
-      validate_re("$token", '^[0-9a-zA-Z\-]+$', 'You need to provide a valid token. See https://github.com/tubemogul/puppet-maxscale#before-you-begin for more details.')
+      # From stdlib doc: Compilation terminates if the first argument is not a string. Always use quotes to force stringification
+      # Dirty hack to avoid only_variable_string lint issue
+      validate_re("-${token}", '^-[0-9a-zA-Z\-]+$', 'You need to provide a valid token. See https://github.com/tubemogul/puppet-maxscale#before-you-begin for more details.')
     }
   }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -39,7 +39,7 @@ class maxscale::install {
         } ->
         yumrepo { 'maxscale':
           enabled  => '1',
-          descr    => "MariaDB-MaxScale",
+          descr    => 'MariaDB-MaxScale',
           baseurl  => $repo_location,
           gpgcheck => '1',
           gpgkey   => 'file:///etc/pki/rpm-gpg/MariaDB-MaxScale-GPG-KEY',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -28,7 +28,7 @@ class maxscale::params {
       $repo_keyserver   = ''
       $repo_release     = ''
       if $::operatingsystem == 'RedHat' {
-        $_os            = "rhel"
+        $_os            = 'rhel'
       } else {
         $_os            = downcase($::operatingsystem)
       }

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -15,12 +15,12 @@ describe 'maxscale class' do
     end
 
     describe package('maxscale') do
-      it { should be_installed }
+      it { is_expected.to be_installed }
     end
 
     describe service('maxscale') do
-      it { should be_enabled }
-      it { should be_running }
+      it { is_expected.to be_enabled }
+      it { is_expected.to be_running }
     end
   end
 end

--- a/spec/classes/maxscale_spec.rb
+++ b/spec/classes/maxscale_spec.rb
@@ -59,7 +59,7 @@ describe 'maxscale' do
 
         it { should create_class('maxscale') }
         it { should contain_class('maxscale::params') }
-        it { should contain_class('maxscale::install').that_comes_before('maxscale::config') }
+        it { should contain_class('maxscale::install').that_comes_before('Class[maxscale::config]') }
         it { should contain_class('maxscale::config') }
 
         it do
@@ -141,7 +141,7 @@ describe 'maxscale' do
 
         it { should create_class('maxscale') }
         it { should contain_class('maxscale::params') }
-        it { should contain_class('maxscale::install').that_comes_before('maxscale::config') }
+        it { should contain_class('maxscale::install').that_comes_before('Class[maxscale::config]') }
         it { should contain_class('maxscale::config') }
 
         case osfamily

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,10 +1,8 @@
 require 'beaker-rspec/spec_helper'
 require 'beaker-rspec/helpers/serverspec'
+require 'beaker/puppet_install_helper'
 
-hosts.each do |host|
-  # Install Puppet
-  install_puppet
-end
+run_puppet_install_helper unless ENV['BEAKER_provision'] == 'no'
 
 RSpec.configure do |c|
   # Project root


### PR DESCRIPTION
Upgrading to the latest puppet-module-skeleton version to get the latest features.

Also fixing some newly introduced problems (lint warnings):
```
manifests/init.pp - WARNING: string containing only a variable on line 38
manifests/init.pp - WARNING: variable not enclosed in {} on line 38
manifests/install.pp - WARNING: double quoted string containing no variables on line 42
manifests/params.pp - WARNING: double quoted string containing no variables on line 31
```