### PR TITLE
Add support for systemd services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Added support for systemd services
 
 ## [1.1.1] - 2017-01-30
 ### Changed

--- a/README.markdown
+++ b/README.markdown
@@ -79,10 +79,16 @@ the "Your Subscriptions" section.
 you can create an account at My Portal, sign the Evaluation Agreement,
 and try MariaDB Enterprise as an Evaluation User.
 
+**Attention:** if you are using the init provider for a systemd-based OS, you
+will have to run `systemctl deamon-reload` manually on the server when changing
+the configuration or adding service. When using the systemd provider, puppet
+takes care of it for you.
+
 ###What Maxscale affects
 
  * `/etc/init.d/maxscale`: used to manage the Maxscale service if you setup the instance 'default'.
  * `/etc/init.d/maxscale_<instance_name>`: used to manage non-default Maxscale instances.
+ * `/lib/systemd/system/maxscale*`: only if you use systemd as your service provider.
  * `/root/.maxadmin`: used to setup the authentication credentials to use with maxadmin. (You can change the directory of the maxadmin file using the [`maxadmin_config_root`](#maxadmin_config_root) parameter.
 
 Files and directories that you specify in your configuration:
@@ -771,19 +777,20 @@ This is a hash containing:
 Default:
 ```puppet
 {
-  'default'        => {
-    ensure         => 'running',
-    logdir         => '/var/log/maxscale',
-    cachedir       => '/var/cache/maxscale',
-    datadir        => '/var/cache/maxscale',
-    piddir         => '/var/run/maxscale',
-    svcuser        => 'maxscale',
-    svcgroup       => 'maxscale',
-    errmsgsys_path => '/var/lib/maxscale',
-    configfile     => '/etc/maxscale.cnf',
-    config         => {
-      'maxscale'   => {
-        'threads'  => 2
+  'default'          => {
+    ensure           => 'running',
+    logdir           => '/var/log/maxscale',
+    cachedir         => '/var/cache/maxscale',
+    datadir          => '/var/cache/maxscale',
+    piddir           => '/var/run/maxscale',
+    svcuser          => 'maxscale',
+    svcgroup         => 'maxscale',
+    errmsgsys_path   => '/var/lib/maxscale',
+    configfile       => '/etc/maxscale.cnf',
+    service_provider => 'init'
+    config           => {
+      'maxscale'     => {
+        'threads'    => 2
       },
       'Binlog_Service'   => {
         'type'           => 'service',

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -1,17 +1,18 @@
 # == Define: maxscale::instance
 #
 define maxscale::instance (
-  $ensure         = 'running',
-  $config         = {},
-  $logdir         = '/var/log/maxscale',
-  $cachedir       = '/var/cache/maxscale',
-  $datadir        = '/var/cache/maxscale',
-  $piddir         = '/var/run/maxscale',
-  $svcuser        = 'maxscale',
-  $svcgroup       = 'maxscale',
-  $errmsgsys_path = '/var/lib/maxscale',
-  $configfile     = '/etc/maxscale.cnf',
-  $master_ini     = { directory => '/var/cache/maxscale/binlog', content => {}, },
+  $ensure           = 'running',
+  $config           = {},
+  $logdir           = '/var/log/maxscale',
+  $cachedir         = '/var/cache/maxscale',
+  $datadir          = '/var/cache/maxscale',
+  $piddir           = '/var/run/maxscale',
+  $svcuser          = 'maxscale',
+  $svcgroup         = 'maxscale',
+  $errmsgsys_path   = '/var/lib/maxscale',
+  $configfile       = '/etc/maxscale.cnf',
+  $master_ini       = { directory => '/var/cache/maxscale/binlog', content => {}, },
+  $service_provider = 'init',
 ){
   # The default instance is just named maxscale. The other ones have a prefix
   # with the name of the instance.
@@ -29,7 +30,7 @@ define maxscale::instance (
     owner  => $svcuser,
     group  => $svcgroup,
     require => [ Class['maxscale::install'], ],
-})
+  })
 
   # The config file could be /etc so we do not want the service user to be the
   # owner. Plus Maxscale don't need to write in it, just need the rights on the
@@ -58,9 +59,20 @@ define maxscale::instance (
     }
   }
 
-  file { "/etc/init.d/${service_name}":
+  $service_template = $service_provider ? {
+    'init'    => "maxscale/maxscale.initd.${::osfamily}.erb",
+    'systemd' => 'maxscale/maxscale.systemd.erb',
+    default   => fail('service provider not supported by the module'),
+  }
+  $service_file = $service_provider ? {
+    'init'    => "/etc/init.d/${service_name}",
+    'systemd' => "/lib/systemd/system/${service_name}.service",
+    default   => fail('service provider not supported by the module'),
+  }
+
+  file { $service_file:
     ensure  => present,
-    content => template("maxscale/maxscale.initd.${::osfamily}.erb"),
+    content => template($service_template),
     mode    => '0755',
     require => File[$configfile],
     notify  => Service[$service_name],
@@ -68,9 +80,19 @@ define maxscale::instance (
 
   service { $service_name:
     ensure     => $ensure,
+    provider   => $service_provider,
+    enable     => true,
     hasrestart => true,
     hasstatus  => true,
-    subscribe  => [ File[$configfile], File["/etc/init.d/${service_name}"], ],
+    subscribe  => [ File[$configfile], File[$service_file], ],
+  }
+
+  if $service_provider == 'systemd' {
+    exec { 'refresh_systemd':
+      command     => '/bin/systemctl daemon-reload',
+      refreshonly => true,
+      subscribe   => [ Service[$service_name], ],
+    }
   }
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -40,19 +40,20 @@ class maxscale::params {
   }
 
   $services_conf = {
-    'default'        => {
-      ensure         => 'running',
-      logdir         => '/var/log/maxscale',
-      cachedir       => '/var/cache/maxscale',
-      datadir        => '/var/cache/maxscale',
-      piddir         => '/var/run/maxscale',
-      svcuser        => 'maxscale',
-      svcgroup       => 'maxscale',
-      errmsgsys_path => '/var/lib/maxscale',
-      configfile     => '/etc/maxscale.cnf',
-      'config'       => {
-        'maxscale'   => {
-          'threads'  => 2,
+    'default'          => {
+      ensure           => 'running',
+      logdir           => '/var/log/maxscale',
+      cachedir         => '/var/cache/maxscale',
+      datadir          => '/var/cache/maxscale',
+      piddir           => '/var/run/maxscale',
+      svcuser          => 'maxscale',
+      svcgroup         => 'maxscale',
+      errmsgsys_path   => '/var/lib/maxscale',
+      service_provider => 'init',
+      configfile       => '/etc/maxscale.cnf',
+      'config'         => {
+        'maxscale'     => {
+          'threads'    => 2,
         },
         'Binlog_Service'   => {
           'type'           => 'service',

--- a/templates/maxscale.systemd.erb
+++ b/templates/maxscale.systemd.erb
@@ -1,0 +1,15 @@
+[Unit]
+Description=MariaDB MaxScale Database Proxy
+After=network.target
+
+[Service]
+Type=forking
+Restart=on-abnormal
+PIDFile=<%= @piddir %>/maxscale.pid
+ExecStartPre=/usr/bin/install -d /var/run/maxscale -o <%= @svcuser %> -g <%= @svcgroup %>
+ExecStart=/usr/bin/maxscale --user=<%= @svcuser %> --config=<%= @configfile %> --datadir=<%= @datadir %> --log=file --logdir=<%= @logdir %> --cachedir=<%= @cachedir %> --piddir=<%= @piddir %> --language=<%=@errmsgsys_path %>
+TimeoutStartSec=120
+LimitNOFILE=65535
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Adds the support for using systemd-based services as an alternative to the init scripts.
In addition, it reloads the deamons as needed with systemd when registering new services.